### PR TITLE
Update awscli utility to 1.10.66

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ ENTRYPOINT ["/usr/bin/aws"]
 CMD ["help"]
 
 RUN apk-install less=475-r0 groff=1.22.3-r0 py-pip=1.5.6-r2
-RUN pip install awscli==1.7.26
+RUN pip install awscli==1.10.66


### PR DESCRIPTION
Howdy @JeanMertz saw this on dockerhub while searching for a lightweight container that wraps aws-cli. However, I need a newer version of the utility so I updated the version flag and built the container... looks to work locally for me.

Please consider merging. Thanks!
